### PR TITLE
bump actions/[upload|download]-artifact to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - run: python src/main.py resume
       - run: python src/main.py resume-simple
       - name: upload generated latex
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: gen-tex-files-artifacts
           path: dist/*.tex
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: copy artifact from gen-tex-files-artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v6
         with:
           name: gen-tex-files-artifacts
           path: dist/
@@ -34,7 +34,7 @@ jobs:
       - run: lualatex resume-simple.tex
         working-directory: dist/
       - name: upload generated pdf
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: generate-pdf-artifacts
           path: dist/*.pdf
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: copy artifact from generate-pdf-artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v6
         with:
           name: generate-pdf-artifacts
           path: publish/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
   generate-pdf-files:
     runs-on: ubuntu-latest
-    container: blang/latex:ubuntu
+    container: texlive/texlive:latest
     needs: gen-tex-files
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
           name: gen-tex-files-artifacts
           path: dist/
       - run: cp resources/mcdowellcv.cls dist
-      - run: lualatex resume.tex
+      - run: pdflatex resume.tex
         working-directory: dist/
-      - run: lualatex resume-simple.tex
+      - run: pdflatex resume-simple.tex
         working-directory: dist/
       - name: upload generated pdf
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
v2 is deprecated